### PR TITLE
Update en.yaml

### DIFF
--- a/yaml/en.yaml
+++ b/yaml/en.yaml
@@ -1,7 +1,7 @@
 tag: en
 version: 1.0
 isReferenceLGR: true
-permittedVariantPolicies: ["mayallocatevar","allblockvar"]
+permittedVariantPolicies: ["allblockvar"]
 eppSafeCodePoints:
   - U+0067
   - U+0071
@@ -25,4 +25,4 @@ testLabels:
     # Contains code points not part of the repertoire
     - xn--mvqry-cra
     # Contains extended-cp code point
-    - xntõhzkcpz
+    - xn--nave-6pa


### PR DESCRIPTION
Bugs fix: 
1. Remove “mayallocatevar” from permittedVariantPolicies as variant definition for English is only applicable with extended code points. Extended code points are disabled by default. 
2. Correct the test label under “Contains extended-cp code point”