### PR TITLE
Update zh.yaml to remove the variants which block each other.

### DIFF
--- a/yaml/full-variant-set/zh.yaml
+++ b/yaml/full-variant-set/zh.yaml
@@ -39,8 +39,6 @@ testLabels:
           variantTLDAllocatability: []
         - label: xn--h7k9t3h90nw6efpb108dpuw
           variantTLDAllocatability: []
-        - label: xn--h7k9t3h90nw6efpb108dxuw
-          variantTLDAllocatability: ["zh","und-Hani"]
         - label: xn--h7k9t3h90nw6efpbo05dn4x
           variantTLDAllocatability: []
         - label: xn--h7k9t3h90nw6efpb208dmuw


### PR DESCRIPTION
There is no requirement as per the current policy.